### PR TITLE
Administrator can block access to users

### DIFF
--- a/src/main/java/todolist/controller/LoginController.java
+++ b/src/main/java/todolist/controller/LoginController.java
@@ -76,6 +76,9 @@ public class LoginController {
         } else if (loginStatus == UsuarioService.LoginStatus.ERROR_PASSWORD) {
             model.addAttribute("error", "Contraseña incorrecta");
             return "formLogin";
+        } else if (loginStatus == UsuarioService.LoginStatus.USER_DISABLED) {
+            model.addAttribute("error", "Usuario deshabilitado");
+            return "formLogin";
         }
         return "formLogin";
     }

--- a/src/main/java/todolist/controller/LoginController.java
+++ b/src/main/java/todolist/controller/LoginController.java
@@ -142,4 +142,11 @@ public class LoginController {
 
         return "descripcionUsuario";
     }
+
+    @PostMapping("/registered/{id}/toggle-enabled")
+    public String toggleEnabledUser(@PathVariable Long id) {
+        comprobarAdministradorLogeado();
+        usuarioService.toggleEnabledUsuario(id);
+        return "redirect:/registered";
+    }
 }

--- a/src/main/java/todolist/dto/UsuarioData.java
+++ b/src/main/java/todolist/dto/UsuarioData.java
@@ -12,6 +12,7 @@ public class UsuarioData {
     private String password;
     private Date fechaNacimiento;
     private boolean admin;
+    private boolean enabled;
 
     // Getters y setters
 
@@ -39,9 +40,13 @@ public class UsuarioData {
         this.nombre = nombre;
     }
 
-    public void setPassword(String password) { this.password = password; }
+    public void setPassword(String password) {
+        this.password = password;
+    }
 
-    public String getPassword() { return password; }
+    public String getPassword() {
+        return password;
+    }
 
     public Date getFechaNacimiento() {
         return fechaNacimiento;
@@ -51,9 +56,21 @@ public class UsuarioData {
         this.fechaNacimiento = fechaNacimiento;
     }
 
-    public boolean isAdmin() { return admin; }
+    public boolean isAdmin() {
+        return admin;
+    }
 
-    public void setAdmin(boolean admin) { this.admin = admin; }
+    public void setAdmin(boolean admin) {
+        this.admin = admin;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     // Sobreescribimos equals y hashCode para que dos usuarios sean iguales
     // si tienen el mismo ID (ignoramos el resto de atributos)

--- a/src/main/java/todolist/model/Usuario.java
+++ b/src/main/java/todolist/model/Usuario.java
@@ -22,6 +22,7 @@ public class Usuario implements Serializable {
     private String nombre;
     private String password;
     private boolean admin;
+    private boolean enabled = true;
     @Column(name = "fecha_nacimiento")
     @Temporal(TemporalType.DATE)
     private Date fechaNacimiento;
@@ -38,6 +39,7 @@ public class Usuario implements Serializable {
     // Constructor público con los atributos obligatorios. En este caso el correo electrónico.
     public Usuario(String email) {
         this.email = email;
+        this.enabled = true;
     }
 
     // Getters y setters atributos básicos
@@ -82,9 +84,21 @@ public class Usuario implements Serializable {
         this.fechaNacimiento = fechaNacimiento;
     }
 
-    public boolean isAdmin() { return admin; }
+    public boolean isAdmin() {
+        return admin;
+    }
 
-    public void setAdmin(boolean admin) { this.admin = admin; }
+    public void setAdmin(boolean admin) {
+        this.admin = admin;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     // Getters y setters de la relación
 

--- a/src/main/java/todolist/service/UsuarioService.java
+++ b/src/main/java/todolist/service/UsuarioService.java
@@ -92,4 +92,19 @@ public class UsuarioService {
                 .map(usuario -> modelMapper.map(usuario, UsuarioData.class))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public UsuarioData toggleEnabledUsuario(Long usuarioId) {
+        logger.debug("Cambiando estado enabled del usuario " + usuarioId);
+        Usuario usuario = usuarioRepository.findById(usuarioId).orElse(null);
+
+        if (usuario == null) {
+            throw new UsuarioServiceException("El usuario " + usuarioId + " no existe");
+        }
+
+        usuario.setEnabled(!usuario.isEnabled());
+        usuario = usuarioRepository.save(usuario);
+
+        return modelMapper.map(usuario, UsuarioData.class);
+    }
 }

--- a/src/main/java/todolist/service/UsuarioService.java
+++ b/src/main/java/todolist/service/UsuarioService.java
@@ -20,7 +20,7 @@ public class UsuarioService {
 
     Logger logger = LoggerFactory.getLogger(UsuarioService.class);
 
-    public enum LoginStatus {LOGIN_OK, USER_NOT_FOUND, ERROR_PASSWORD}
+    public enum LoginStatus {LOGIN_OK, USER_NOT_FOUND, ERROR_PASSWORD, USER_DISABLED}
 
     @Autowired
     private UsuarioRepository usuarioRepository;
@@ -32,6 +32,8 @@ public class UsuarioService {
         Optional<Usuario> usuario = usuarioRepository.findByEmail(eMail);
         if (!usuario.isPresent()) {
             return LoginStatus.USER_NOT_FOUND;
+        } else if (!usuario.get().isEnabled()) {
+            return LoginStatus.USER_DISABLED;
         } else if (!usuario.get().getPassword().equals(password)) {
             return LoginStatus.ERROR_PASSWORD;
         } else {
@@ -53,6 +55,7 @@ public class UsuarioService {
             throw new UsuarioServiceException("El usuario no tiene password");
         else {
             Usuario usuarioNuevo = modelMapper.map(usuario, Usuario.class);
+            usuarioNuevo.setEnabled(true);
             usuarioNuevo = usuarioRepository.save(usuarioNuevo);
             return modelMapper.map(usuarioNuevo, UsuarioData.class);
         }

--- a/src/main/resources/templates/listaUsuarios.html
+++ b/src/main/resources/templates/listaUsuarios.html
@@ -35,10 +35,20 @@
                     <td th:text="${usuario.id}"></td>
                     <td th:text="${usuario.email}"></td>
                     <td>
-                        <a class="btn btn-primary btn-sm"
+                        <a class="btn btn-primary btn-sm mr-2"
                            th:href="@{/registered/{id}(id=${usuario.id})}">
                             View description
                         </a>
+
+                        <form method="post"
+                              th:action="@{/registered/{id}/toggle-enabled(id=${usuario.id})}"
+                              style="display: inline;">
+                            <button type="submit"
+                                    class="btn btn-warning btn-sm"
+                                    th:text="${usuario.enabled} ? 'Disable' : 'Enable'">
+                                Disable
+                            </button>
+                        </form>
                     </td>
                 </tr>
 

--- a/src/test/java/todolist/controller/UsuarioWebTest.java
+++ b/src/test/java/todolist/controller/UsuarioWebTest.java
@@ -95,6 +95,17 @@ public class UsuarioWebTest {
     }
 
     @Test
+    public void servicioLoginUsuarioDeshabilitado() throws Exception {
+        when(usuarioService.login("ana.garcia@gmail.com", "12345678"))
+                .thenReturn(UsuarioService.LoginStatus.USER_DISABLED);
+
+        this.mockMvc.perform(post("/login")
+                        .param("eMail", "ana.garcia@gmail.com")
+                        .param("password", "12345678"))
+                .andExpect(content().string(containsString("Usuario deshabilitado")));
+    }
+
+    @Test
     public void listadoUsuariosRegistradosDevuelvePaginaConUsuarios() throws Exception {
         UsuarioData admin = new UsuarioData();
         admin.setId(99L);
@@ -104,10 +115,12 @@ public class UsuarioWebTest {
         UsuarioData usuario1 = new UsuarioData();
         usuario1.setId(1L);
         usuario1.setEmail("richard@umh.es");
+        usuario1.setEnabled(true);
 
         UsuarioData usuario2 = new UsuarioData();
         usuario2.setId(2L);
         usuario2.setEmail("ada@umh.es");
+        usuario2.setEnabled(false);
 
         when(managerUserSession.usuarioLogeado())
                 .thenReturn(99L);
@@ -124,7 +137,9 @@ public class UsuarioWebTest {
                         containsString("richard@umh.es"),
                         containsString("ada@umh.es"),
                         containsString("1"),
-                        containsString("2")
+                        containsString("2"),
+                        containsString("Disable"),
+                        containsString("Enable")
                 )));
     }
 
@@ -160,5 +175,31 @@ public class UsuarioWebTest {
                         containsString("Richard Stallman")
                 )))
                 .andExpect(content().string(not(containsString("1234"))));
+    }
+
+    @Test
+    public void administradorPuedeCambiarEstadoDeAccesoDeUsuario() throws Exception {
+        UsuarioData admin = new UsuarioData();
+        admin.setId(99L);
+        admin.setEmail("admin@umh.es");
+        admin.setAdmin(true);
+
+        UsuarioData usuarioActualizado = new UsuarioData();
+        usuarioActualizado.setId(1L);
+        usuarioActualizado.setEmail("richard@umh.es");
+        usuarioActualizado.setEnabled(false);
+
+        when(managerUserSession.usuarioLogeado())
+                .thenReturn(99L);
+
+        when(usuarioService.findById(99L))
+                .thenReturn(admin);
+
+        when(usuarioService.toggleEnabledUsuario(1L))
+                .thenReturn(usuarioActualizado);
+
+        this.mockMvc.perform(post("/registered/1/toggle-enabled"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/registered"));
     }
 }

--- a/src/test/java/todolist/service/UsuarioServiceTest.java
+++ b/src/test/java/todolist/service/UsuarioServiceTest.java
@@ -41,6 +41,17 @@ public class UsuarioServiceTest {
     }
 
     @Test
+    public void servicioLoginUsuarioDeshabilitado() {
+        Long usuarioId = addUsuarioBD();
+
+        usuarioService.toggleEnabledUsuario(usuarioId);
+
+        UsuarioService.LoginStatus loginStatus = usuarioService.login("richard@umh.es", "1234");
+
+        assertThat(loginStatus).isEqualTo(UsuarioService.LoginStatus.USER_DISABLED);
+    }
+
+    @Test
     public void servicioRegistroUsuario() {
         UsuarioData usuario = new UsuarioData();
         usuario.setEmail("usuario.prueba2@gmail.com");
@@ -129,5 +140,19 @@ public class UsuarioServiceTest {
         assertThat(usuario.getId()).isEqualTo(usuarioId);
         assertThat(usuario.getEmail()).isEqualTo("richard@umh.es");
         assertThat(usuario.getNombre()).isEqualTo("Richard Stallman");
+    }
+
+    @Test
+    public void servicioToggleEnabledUsuarioCambiaEstadoDelUsuario() {
+        Long usuarioId = addUsuarioBD();
+
+        UsuarioData usuarioInicial = usuarioService.findById(usuarioId);
+        assertThat(usuarioInicial.isEnabled()).isTrue();
+
+        UsuarioData usuarioDeshabilitado = usuarioService.toggleEnabledUsuario(usuarioId);
+        assertThat(usuarioDeshabilitado.isEnabled()).isFalse();
+
+        UsuarioData usuarioHabilitado = usuarioService.toggleEnabledUsuario(usuarioId);
+        assertThat(usuarioHabilitado.isEnabled()).isTrue();
     }
 }


### PR DESCRIPTION
## Description

This feature allows the administrator to enable or disable access to registered users.

Changes implemented:

- Added enabled attribute to Usuario entity and DTO
- Prevented login for disabled users
- Added toggle functionality in UsuarioService
- Added controller endpoint to enable or disable users
- Added Enable/Disable button in registered users list
- Added service and web tests for the new functionality

Manual testing performed successfully:

- Administrator can enable or disable users from /registered
- Disabled users cannot log in
- System shows "Usuario deshabilitado" message
- Re-enabled users can log in again
- Existing functionality remains unaffected

Closes #13