### PR TITLE
Configure Docker image for external PostgreSQL parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY target/*.jar app.jar
 # https://programmer.help/blogs/page-opening-stuck-when-using-httpsession-in-springboot-under-openjdk.html
 # Más información:
 # https://www.digitalocean.com/community/tutorials/how-to-setup-additional-entropy-for-cloud-servers-using-haveged
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/urandom","-jar","/app.jar"]
+ENTRYPOINT ["sh","-c","java -Djava.security.egd=file:/dev/urandom -jar /app.jar ${0} ${@}"]

--- a/src/main/resources/application-postgres.properties
+++ b/src/main/resources/application-postgres.properties
@@ -1,4 +1,9 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/atsd
-spring.datasource.username=atsd
-spring.datasource.password=atsd
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+DB_USER=atsd
+DB_PASSWD=atsd
+
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/atsd
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWD}
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Closes #38

Updated Dockerfile to allow passing Spring Boot execution parameters to the container.

Updated PostgreSQL profile to use configurable database connection parameters.