### PR TITLE
Add production profile and database schema management

### DIFF
--- a/sql/schema-1.2.0.sql
+++ b/sql/schema-1.2.0.sql
@@ -1,0 +1,224 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict tVPCgpeU9MqXHlF4YERK95HI9ouhvgxRcZKvE5EkzWrwFDlXgIXpHH5JzSL1cMj
+
+-- Dumped from database version 13.23 (Debian 13.23-1.pgdg13+1)
+-- Dumped by pg_dump version 13.23 (Debian 13.23-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: equipo_usuario; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.equipo_usuario (
+    fk_equipo bigint NOT NULL,
+    fk_usuario bigint NOT NULL
+);
+
+
+ALTER TABLE public.equipo_usuario OWNER TO atsd;
+
+--
+-- Name: equipos; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.equipos (
+    id bigint NOT NULL,
+    nombre character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.equipos OWNER TO atsd;
+
+--
+-- Name: equipos_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.equipos_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.equipos_id_seq OWNER TO atsd;
+
+--
+-- Name: equipos_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.equipos_id_seq OWNED BY public.equipos.id;
+
+
+--
+-- Name: tareas; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.tareas (
+    id bigint NOT NULL,
+    titulo character varying(255) NOT NULL,
+    usuario_id bigint NOT NULL
+);
+
+
+ALTER TABLE public.tareas OWNER TO atsd;
+
+--
+-- Name: tareas_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.tareas_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.tareas_id_seq OWNER TO atsd;
+
+--
+-- Name: tareas_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.tareas_id_seq OWNED BY public.tareas.id;
+
+
+--
+-- Name: usuarios; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.usuarios (
+    id bigint NOT NULL,
+    admin boolean NOT NULL,
+    email character varying(255) NOT NULL,
+    enabled boolean NOT NULL,
+    fecha_nacimiento date,
+    nombre character varying(255),
+    password character varying(255)
+);
+
+
+ALTER TABLE public.usuarios OWNER TO atsd;
+
+--
+-- Name: usuarios_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.usuarios_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.usuarios_id_seq OWNER TO atsd;
+
+--
+-- Name: usuarios_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.usuarios_id_seq OWNED BY public.usuarios.id;
+
+
+--
+-- Name: equipos id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipos ALTER COLUMN id SET DEFAULT nextval('public.equipos_id_seq'::regclass);
+
+
+--
+-- Name: tareas id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas ALTER COLUMN id SET DEFAULT nextval('public.tareas_id_seq'::regclass);
+
+
+--
+-- Name: usuarios id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.usuarios ALTER COLUMN id SET DEFAULT nextval('public.usuarios_id_seq'::regclass);
+
+
+--
+-- Name: equipo_usuario equipo_usuario_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT equipo_usuario_pkey PRIMARY KEY (fk_equipo, fk_usuario);
+
+
+--
+-- Name: equipos equipos_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipos
+    ADD CONSTRAINT equipos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tareas tareas_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas
+    ADD CONSTRAINT tareas_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usuarios usuarios_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.usuarios
+    ADD CONSTRAINT usuarios_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tareas fkdmoaxl7yv4q6vkc9h32wvbddr; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas
+    ADD CONSTRAINT fkdmoaxl7yv4q6vkc9h32wvbddr FOREIGN KEY (usuario_id) REFERENCES public.usuarios(id);
+
+
+--
+-- Name: equipo_usuario fkk4y9gec15ccnirp3r7w29o66p; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT fkk4y9gec15ccnirp3r7w29o66p FOREIGN KEY (fk_equipo) REFERENCES public.equipos(id);
+
+
+--
+-- Name: equipo_usuario fksabsvjgvfuen6hmyg7gn7oq4v; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT fksabsvjgvfuen6hmyg7gn7oq4v FOREIGN KEY (fk_usuario) REFERENCES public.usuarios(id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict tVPCgpeU9MqXHlF4YERK95HI9ouhvgxRcZKvE5EkzWrwFDlXgIXpHH5JzSL1cMj
+

--- a/sql/sql-backup15052026.sql
+++ b/sql/sql-backup15052026.sql
@@ -1,0 +1,294 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict E2cfPE6qbviYrOUo0uUILHd4teb8bqwWC1HdLN0dsa92wOaJOEo7JkSHgVJsaER
+
+-- Dumped from database version 13.23 (Debian 13.23-1.pgdg13+1)
+-- Dumped by pg_dump version 13.23 (Debian 13.23-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+ALTER TABLE ONLY public.equipo_usuario DROP CONSTRAINT fksabsvjgvfuen6hmyg7gn7oq4v;
+ALTER TABLE ONLY public.equipo_usuario DROP CONSTRAINT fkk4y9gec15ccnirp3r7w29o66p;
+ALTER TABLE ONLY public.tareas DROP CONSTRAINT fkdmoaxl7yv4q6vkc9h32wvbddr;
+ALTER TABLE ONLY public.usuarios DROP CONSTRAINT usuarios_pkey;
+ALTER TABLE ONLY public.tareas DROP CONSTRAINT tareas_pkey;
+ALTER TABLE ONLY public.equipos DROP CONSTRAINT equipos_pkey;
+ALTER TABLE ONLY public.equipo_usuario DROP CONSTRAINT equipo_usuario_pkey;
+ALTER TABLE public.usuarios ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE public.tareas ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE public.equipos ALTER COLUMN id DROP DEFAULT;
+DROP SEQUENCE public.usuarios_id_seq;
+DROP TABLE public.usuarios;
+DROP SEQUENCE public.tareas_id_seq;
+DROP TABLE public.tareas;
+DROP SEQUENCE public.equipos_id_seq;
+DROP TABLE public.equipos;
+DROP TABLE public.equipo_usuario;
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: equipo_usuario; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.equipo_usuario (
+    fk_equipo bigint NOT NULL,
+    fk_usuario bigint NOT NULL
+);
+
+
+ALTER TABLE public.equipo_usuario OWNER TO atsd;
+
+--
+-- Name: equipos; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.equipos (
+    id bigint NOT NULL,
+    nombre character varying(255) NOT NULL
+);
+
+
+ALTER TABLE public.equipos OWNER TO atsd;
+
+--
+-- Name: equipos_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.equipos_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.equipos_id_seq OWNER TO atsd;
+
+--
+-- Name: equipos_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.equipos_id_seq OWNED BY public.equipos.id;
+
+
+--
+-- Name: tareas; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.tareas (
+    id bigint NOT NULL,
+    titulo character varying(255) NOT NULL,
+    usuario_id bigint NOT NULL
+);
+
+
+ALTER TABLE public.tareas OWNER TO atsd;
+
+--
+-- Name: tareas_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.tareas_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.tareas_id_seq OWNER TO atsd;
+
+--
+-- Name: tareas_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.tareas_id_seq OWNED BY public.tareas.id;
+
+
+--
+-- Name: usuarios; Type: TABLE; Schema: public; Owner: atsd
+--
+
+CREATE TABLE public.usuarios (
+    id bigint NOT NULL,
+    admin boolean NOT NULL,
+    email character varying(255) NOT NULL,
+    enabled boolean NOT NULL,
+    fecha_nacimiento date,
+    nombre character varying(255),
+    password character varying(255)
+);
+
+
+ALTER TABLE public.usuarios OWNER TO atsd;
+
+--
+-- Name: usuarios_id_seq; Type: SEQUENCE; Schema: public; Owner: atsd
+--
+
+CREATE SEQUENCE public.usuarios_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.usuarios_id_seq OWNER TO atsd;
+
+--
+-- Name: usuarios_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: atsd
+--
+
+ALTER SEQUENCE public.usuarios_id_seq OWNED BY public.usuarios.id;
+
+
+--
+-- Name: equipos id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipos ALTER COLUMN id SET DEFAULT nextval('public.equipos_id_seq'::regclass);
+
+
+--
+-- Name: tareas id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas ALTER COLUMN id SET DEFAULT nextval('public.tareas_id_seq'::regclass);
+
+
+--
+-- Name: usuarios id; Type: DEFAULT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.usuarios ALTER COLUMN id SET DEFAULT nextval('public.usuarios_id_seq'::regclass);
+
+
+--
+-- Data for Name: equipo_usuario; Type: TABLE DATA; Schema: public; Owner: atsd
+--
+
+COPY public.equipo_usuario (fk_equipo, fk_usuario) FROM stdin;
+\.
+
+
+--
+-- Data for Name: equipos; Type: TABLE DATA; Schema: public; Owner: atsd
+--
+
+COPY public.equipos (id, nombre) FROM stdin;
+\.
+
+
+--
+-- Data for Name: tareas; Type: TABLE DATA; Schema: public; Owner: atsd
+--
+
+COPY public.tareas (id, titulo, usuario_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: usuarios; Type: TABLE DATA; Schema: public; Owner: atsd
+--
+
+COPY public.usuarios (id, admin, email, enabled, fecha_nacimiento, nombre, password) FROM stdin;
+\.
+
+
+--
+-- Name: equipos_id_seq; Type: SEQUENCE SET; Schema: public; Owner: atsd
+--
+
+SELECT pg_catalog.setval('public.equipos_id_seq', 1, false);
+
+
+--
+-- Name: tareas_id_seq; Type: SEQUENCE SET; Schema: public; Owner: atsd
+--
+
+SELECT pg_catalog.setval('public.tareas_id_seq', 1, false);
+
+
+--
+-- Name: usuarios_id_seq; Type: SEQUENCE SET; Schema: public; Owner: atsd
+--
+
+SELECT pg_catalog.setval('public.usuarios_id_seq', 1, false);
+
+
+--
+-- Name: equipo_usuario equipo_usuario_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT equipo_usuario_pkey PRIMARY KEY (fk_equipo, fk_usuario);
+
+
+--
+-- Name: equipos equipos_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipos
+    ADD CONSTRAINT equipos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tareas tareas_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas
+    ADD CONSTRAINT tareas_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: usuarios usuarios_pkey; Type: CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.usuarios
+    ADD CONSTRAINT usuarios_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tareas fkdmoaxl7yv4q6vkc9h32wvbddr; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.tareas
+    ADD CONSTRAINT fkdmoaxl7yv4q6vkc9h32wvbddr FOREIGN KEY (usuario_id) REFERENCES public.usuarios(id);
+
+
+--
+-- Name: equipo_usuario fkk4y9gec15ccnirp3r7w29o66p; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT fkk4y9gec15ccnirp3r7w29o66p FOREIGN KEY (fk_equipo) REFERENCES public.equipos(id);
+
+
+--
+-- Name: equipo_usuario fksabsvjgvfuen6hmyg7gn7oq4v; Type: FK CONSTRAINT; Schema: public; Owner: atsd
+--
+
+ALTER TABLE ONLY public.equipo_usuario
+    ADD CONSTRAINT fksabsvjgvfuen6hmyg7gn7oq4v FOREIGN KEY (fk_usuario) REFERENCES public.usuarios(id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict E2cfPE6qbviYrOUo0uUILHd4teb8bqwWC1HdLN0dsa92wOaJOEo7JkSHgVJsaER
+

--- a/src/main/resources/application-postgres-prod.properties
+++ b/src/main/resources/application-postgres-prod.properties
@@ -1,0 +1,11 @@
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+DB_USER=atsd
+DB_PASSWD=atsd
+
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/atsd
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWD}
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=validate


### PR DESCRIPTION
Closes #41

Added postgres-prod profile using ddl-auto=validate.

Generated and stored database schema for production deployment.

Added database backup example for production maintenance.