### PR TITLE
Improve about page for release 1.3.0

### DIFF
--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -21,6 +21,7 @@
                 <li>Developed by DANIEL GARCIA</li>
                 <li>Version 1.3.0-SNAPSHOT</li>
                 <li>Release date: pending</li>
+                <li>New feature: team descriptions added</li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Closes #44

Updated About page with information about the new team description feature.